### PR TITLE
Configure environment variables for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,9 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment: github-pages
     env:
-      VITE_API_URL: https://dalestudy-chat-backend.fly.dev
+      VITE_API_URL: ${{ vars.VITE_API_URL }}
     defaults:
       run:
         working-directory: ./frontend


### PR DESCRIPTION
Fixes #8

- Add github-pages environment to build job
- Use repository variables for VITE_API_URL instead of hardcoded value

🤖 Generated with [Claude Code](https://claude.ai/code)